### PR TITLE
Tracelog

### DIFF
--- a/local_execute.sh
+++ b/local_execute.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# For additional debugging info, add: -Djava.security.debug=certpath -D-Djavax.net.debug=all
+# For additional debugging info, add: `-Djava.security.debug=certpath+thread+timestamp -D-Djavax.net.debug=all`
 #
-# mvn clean package spring-boot:repackage; java -Djava.security.debug=certpath -jar target/rest-service-eb.jar --spring.config.name=vss --spring.config.location=file:///opt/vss/ext/conf/
-#
-mvn clean package spring-boot:repackage; java -jar target/rest-service-eb.jar --spring.config.name=vss --spring.config.location=file:///opt/vss/ext/conf/
+/usr/local/bin/mvn clean package spring-boot:repackage; java -Djava.security.debug=certpath+thread+timestamp -jar target/rest-service-eb.jar --spring.config.name=vss --spring.config.location=file:///opt/vss/ext/conf/

--- a/src/main/java/org/keysupport/api/LoggingUtil.java
+++ b/src/main/java/org/keysupport/api/LoggingUtil.java
@@ -1,6 +1,5 @@
 package org.keysupport.api;
 
-import java.io.PrintStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -10,36 +9,9 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-/*
- * The intent of this class is to redirect System.out and System.err to our
- * logging.
- * 
- * This implementation uses the SUN JSSE provider, which offers the follwing tracing mechanism:
- * 
- * -Djava.security.debug=certpath
- * 
- * Perhaps this will be changed in the future to allow for better incorporation into logs.
- * 
- * I.e.,
- * 
- * - https://bugs.openjdk.org/browse/JDK-8202601
- */
 public class LoggingUtil {
 
     private static final Logger LOG = LoggerFactory.getLogger(LoggingUtil.class);
-
-    public static void logSystemOutAndErr() {
-        System.setOut(loggingProxy(System.out));
-        System.setErr(loggingProxy(System.err));
-    }
-
-    public static PrintStream loggingProxy(final PrintStream ps) {
-        return new PrintStream(ps) {
-            public void print(final String str) {
-            	LOG.info(str);
-            }
-        };
-    }
     
     public static String pojoToJson(Object obj) {
 		ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/org/keysupport/api/RestServiceApplication.java
+++ b/src/main/java/org/keysupport/api/RestServiceApplication.java
@@ -7,7 +7,6 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 public class RestServiceApplication {
 
     public static void main(String[] args) {
-    	LoggingUtil.logSystemOutAndErr();
         SpringApplication app = new SpringApplication(RestServiceApplication.class);
         app.run(args);
    }

--- a/src/main/java/org/keysupport/api/pkix/ValidatePKIX.java
+++ b/src/main/java/org/keysupport/api/pkix/ValidatePKIX.java
@@ -335,6 +335,7 @@ public class ValidatePKIX {
 					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
 		}
+		@SuppressWarnings("unchecked")
 		List<X509Certificate> validPath = (List<X509Certificate>) cp.getCertificates();
 		/*
 		 * Intermediate Certificate Discovery

--- a/src/main/java/org/keysupport/api/pkix/ValidatePKIX.java
+++ b/src/main/java/org/keysupport/api/pkix/ValidatePKIX.java
@@ -11,6 +11,7 @@ import java.security.cert.CertPathBuilderException;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.CertStore;
+import java.security.cert.CertStoreException;
 import java.security.cert.CertStoreParameters;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
@@ -21,12 +22,15 @@ import java.security.cert.CollectionCertStoreParameters;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.PKIXCertPathBuilderResult;
 import java.security.cert.PKIXCertPathValidatorResult;
+import java.security.cert.PKIXRevocationChecker;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.Date;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -58,15 +62,29 @@ public class ValidatePKIX {
 
 	/**
 	 * <pre>
-	 * 
-	 * For now, we will stick with the SUN provider since it can fetch CRL and
+	 *
+	 * For now, we will stick with the SUN PKIX provider since it can fetch CRL and
 	 * OCSP data.
+	 *
+	 * Changing CERTPATH_PROVIDER & CERTPATH_ALGORITHM will likely require the re-factoring of this class.
 	 *
 	 * https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/security/provider/certpath/URICertStore.java
 	 *
 	 * If we were to create an internal variant of the SUN URICertStore, then we
 	 * could use it with the BC Certpath provider.
-	 * 
+	 *
+	 * Debug logging for CertPath can be enabled running the code via:
+	 *
+	 * - java -Djava.security.debug=certpath -jar target/rest-service-eb.jar
+	 *
+	 * The following Documentation may be helpful to unravel configuration options:
+	 *
+	 * - https://docs.oracle.com/en/java/javase/21/security/java-pki-programmers-guide.html
+	 * - https://docs.oracle.com/en/java/javase/21/security/troubleshooting-security.html
+	 * - https://openjdk.org/jeps/124
+	 * - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/cert/PKIXRevocationChecker.html
+	 * - https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/cert/PKIXRevocationChecker.Option.html
+	 *
 	 * </pre>
 	 */
 	private final static String CERTPATH_PROVIDER = "SUN";
@@ -81,7 +99,8 @@ public class ValidatePKIX {
 	public static VssResponse validate(X509Certificate cert, String x5tS256, ValidationPolicy valPol, Date now) {
 		ValidationPoliciesSingleton policies = ValidationPoliciesSingleton.getInstance();
 		/*
-		 * SUN JSSE Provider config for revocation checking, but; only for the EE cert being validated
+		 * SUN JSSE Provider config for revocation checking, but; only for the EE cert
+		 * being validated
 		 */
 		if (policies.getRevocationEnabled() && policies.getRevocationEeOnly()) {
 			System.setProperty("com.sun.security.onlyCheckRevocationOfEECert", "true");
@@ -104,74 +123,10 @@ public class ValidatePKIX {
 		if (policies.getAiaChase()) {
 			System.setProperty("com.sun.security.enableAIAcaIssuers", "true");
 		}
-		/**
-		 * <pre>
-		 *  		 
-		 * Begin Set JCE Signature Provider and System/Security variables
-		 *
-		 * Set System and Security properties to make the Sun provider:
-		 * 
-		 * - Fetch CRLs via the CDP extension
-		 * - Check OCSP via the AIA extension
-		 * - Chase CA Issuers via the AIA extension
-		 *
-		 * The AIA and CDP chases would be valuable to update a local cache.
-		 *
-		 * The OCSP responses would be valuable *if* the CA is not able to produce a CRL
-		 * within 24 hours within the FPKI (or any issuing CA or intermediate the
-		 * relying party is willing to trust).
-		 *
-		 * See:
-		 * 
-		 * https://docs.oracle.com/en/java/javase/11/security/java-pki-programmers-guide.html
-		 *
-		 * - https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
-		 *
-		 * Debug logging for CertPath can be enabled running the code via:
-		 *
-		 * - java -Djava.security.debug=certpath -jar target/rest-service-eb.jar
-		 *
-		 * </pre>
-		 */
 		/*
 		 * This implementation will rely on BCFIPS for cryptographic compliance.
 		 */
 		Security.addProvider(new BouncyCastleFipsProvider());
-		/**
-		 * <pre>
-		 * 
-		 * Draft Local OCSP Service providing responses for all FPKI Intermediates.
-		 * 
-		 * See:
-		 * 
-		 * https://docs.oracle.com/en/java/javase/17/security/java-pki-programmers-guide.html#GUID-E6E737DB-4000-4005-969E-BCD0238B1566
-		 * 
-		 * If enabled, we should not rely on the following properties:
-		 * 
-		 * System.setProperty("com.sun.security.enableCRLDP", "true");
-		 * Security.setProperty("ocsp.enable", "true");
-		 * 
-		 * The preference is to not beacon human credential use.  
-		 * 
-		 * It is much more efficient for us to consider local revocation 
-		 * data caching (expecting ~2Gb/24hr for FPKI) via CRLs.
-		 * 
-		 * Some teams *may* want to consider an internal OCSP responder, 
-		 * where the revocation source data is CRL based, and; can 
-		 * discover from any certificate that is successfully validated.
-		 * 
-		 * Below are the properties that should be set in lieu of the 
-		 * System/Security properties above to enable OCSP and CRL DP Download:
-		 * 
-		 * Security.setProperty("ocsp.responderURL", "http://{host}/");
-		 * Security.setProperty("ocsp.responderCertIssuerName", "{issuer}");
-		 * Security.setProperty("ocsp.responderCertSerialNumber", "{signing-cert-serial}");
-		 * 
-		 * </pre>
-		 */
-		/*
-		 * End Set JCE Signature Provider and System/Security variables
-		 */
 		/*
 		 * Process the request
 		 */
@@ -193,7 +148,6 @@ public class ValidatePKIX {
 		if (null != cert.getSerialNumber()) {
 			response.x509SerialNumber = cert.getSerialNumber().toString();
 		}
-
 		if (cert.getBasicConstraints() == -1) {
 			/*
 			 * This is not a CA
@@ -203,12 +157,12 @@ public class ValidatePKIX {
 			/**
 			 * <pre>
 			 * This is a CA:
-			 * 
+			 *
 			 * - https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/cert/V1X509Certificate.html#getBasicConstraints()
-			 * 
+			 *
 			 * "the value of pathLenConstraint if the BasicConstraints extension is present
 			 *  in the certificate and the subject of the certificate is a CA, otherwise -1."
-			 * 
+			 *
 			 * </pre>
 			 */
 			response.isCA = Boolean.TRUE;
@@ -220,11 +174,12 @@ public class ValidatePKIX {
 		try {
 			response.x509SubjectAltName = X509Util.getSubjectAlternativeNames(cert);
 		} catch (IOException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Error parsing Certificate SAN", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Error parsing Certificate SAN", "stacktrace", LoggingUtil.stackTraceToString(e))));
 		}
 		/*
 		 * Add x5t#S256, because we are checking temporal validity next.
-		 * 
+		 *
 		 * We can render a *much* faster validity result in this case.
 		 */
 		response.x5tS256 = x5tS256;
@@ -257,14 +212,16 @@ public class ValidatePKIX {
 		try {
 			cstore = CertStore.getInstance("Collection", cparam, CERTPATH_PROVIDER);
 		} catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException | NoSuchProviderException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
 		}
 		PKIXBuilderParameters params = null;
 		try {
 			params = new PKIXBuilderParameters(taList, selector);
 		} catch (InvalidAlgorithmParameterException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
 		}
 		params.setSigProvider(JCE_PROVIDER);
@@ -276,20 +233,22 @@ public class ValidatePKIX {
 		params.setMaxPathLength(policies.getMaxPathLen());
 		params.addCertStore(cstore);
 		/*
-		 * Disable the following if trying to eliminate revocation checking in the provider.
+		 * Disable the following if trying to eliminate revocation checking in the
+		 * provider.
 		 */
 		params.setRevocationEnabled(policies.getRevocationEnabled());
 		/**
 		 * <pre>
-		 * 
+		 *
 		 * Add Intermediate Store from our IntermediateCacheSingleton
 		 *
 		 * - https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/security/cert/CertStore.html
-		 * 
+		 *
 		 * </pre>
 		 */
 		IntermediateCacheSingleton intermediateCacheSingleton = IntermediateCacheSingleton.getInstance();
-		params.addCertStore(intermediateCacheSingleton.getIntermediates());
+		CertStore intermediateStore = intermediateCacheSingleton.getIntermediates();
+		params.addCertStore(intermediateStore);
 		/*
 		 * Build the certificate path
 		 */
@@ -297,14 +256,23 @@ public class ValidatePKIX {
 		try {
 			cpb = CertPathBuilder.getInstance(CERTPATH_ALGORITHM, CERTPATH_PROVIDER);
 		} catch (NoSuchAlgorithmException | NoSuchProviderException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
+		}
+		/*
+		 * We will add revocation options during path construction here
+		 */
+		if (policies.getRevocationEnabled() && policies.getRevocationEeOnly()) {
+			PKIXRevocationChecker rc = (PKIXRevocationChecker) cpb.getRevocationChecker();
+			rc.setOptions(EnumSet.of(PKIXRevocationChecker.Option.ONLY_END_ENTITY));
 		}
 		PKIXCertPathBuilderResult result = null;
 		try {
 			result = (PKIXCertPathBuilderResult) cpb.build(params);
 		} catch (InvalidAlgorithmParameterException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Error with CertPathBuilder", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Error with CertPathBuilder", "stacktrace", LoggingUtil.stackTraceToString(e))));
 		} catch (CertPathBuilderException e) {
 			/*
 			 * Construct and return validation response.
@@ -348,7 +316,8 @@ public class ValidatePKIX {
 		try {
 			cpv = CertPathValidator.getInstance(CERTPATH_ALGORITHM);
 		} catch (NoSuchAlgorithmException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
 		}
 		PKIXCertPathValidatorResult pvr = null;
@@ -362,8 +331,46 @@ public class ValidatePKIX {
 			response.validationResult = fail;
 			return response;
 		} catch (InvalidAlgorithmParameterException e) {
-			LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
+			LOG.error(LoggingUtil.pojoToJson(
+					Map.of("error", "Internal Validation Error", "stacktrace", LoggingUtil.stackTraceToString(e))));
 			throw new ServiceException("Internal Validation Error");
+		}
+		List<X509Certificate> validPath = (List<X509Certificate>) cp.getCertificates();
+		/*
+		 * Intermediate Certificate Discovery
+		 *
+		 * The intent of this logic is to see if the intermediates in the built path
+		 * exist in our intermediate cache.
+		 *
+		 * If the certificate does not exist, then we will print a warning message
+		 * suggesting the certificate addition.
+		 */
+		if (policies.getAiaChase()) {
+			for (X509Certificate intermediate : validPath) {
+				if (intermediate.getBasicConstraints() != -1) {
+					X509CertSelector pathSelect = new X509CertSelector();
+					pathSelect.setCertificate(intermediate);
+					Collection<? extends Certificate> cachedPathCerts = null;
+					try {
+						cachedPathCerts = intermediateStore.getCertificates(pathSelect);
+					} catch (CertStoreException e) {
+						LOG.error(LoggingUtil
+								.pojoToJson(Map.of("error", "Internal Intermediate Certificate Discovery Error",
+										"stacktrace", LoggingUtil.stackTraceToString(e))));
+					}
+					if (cachedPathCerts.isEmpty()) {
+						try {
+							LOG.warn(LoggingUtil.pojoToJson(Map.of("warning",
+									"Discovered Intermediate! (not present in cache, consider adding)",
+									"x509Certificate", Base64.getEncoder().encodeToString(intermediate.getEncoded()))));
+						} catch (CertificateEncodingException e) {
+							LOG.error(LoggingUtil
+									.pojoToJson(Map.of("error", "Error Base64 encoding certificate from CertPath",
+											"stacktrace", LoggingUtil.stackTraceToString(e))));
+						}
+					}
+				}
+			}
 		}
 		/*
 		 * If we got this far, the certificate is valid. (Regardless of default
@@ -377,13 +384,14 @@ public class ValidatePKIX {
 		 * Add certPath
 		 */
 		List<JsonX509Certificate> x509CertificatePath = new ArrayList<>();
-		for (Certificate currentCert : cp.getCertificates()) {
+		for (Certificate currentCert : validPath) {
 			JsonX509Certificate bCert = new JsonX509Certificate();
 			try {
 				bCert.x509Certificate = Base64.getEncoder().encodeToString(currentCert.getEncoded());
 				LOG.debug(LoggingUtil.pojoToJson(Map.of("pkix.path.cert", currentCert.toString())));
 			} catch (CertificateEncodingException e) {
-				LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Error Base64 encoding certificate from CertPath", "stacktrace", LoggingUtil.stackTraceToString(e))));
+				LOG.error(LoggingUtil.pojoToJson(Map.of("error", "Error Base64 encoding certificate from CertPath",
+						"stacktrace", LoggingUtil.stackTraceToString(e))));
 			}
 			x509CertificatePath.add(bCert);
 		}
@@ -396,5 +404,5 @@ public class ValidatePKIX {
 		response.validationResult = success;
 		return response;
 	}
-	
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,10 +27,15 @@ service:
   intermediates:
     uri: >-
       https://www.idmanagement.gov/implement/tools/CACertificatesValidatingToFederalCommonPolicyG2.p7b
+  systemlog:
+    enabled: false
+    file: /opt/vss/ext/logs/system.log
   validation:
     pkix:
+# If AIA Chase is enabled, `max-path-length` *might* be ignored
+# Otherwise, `max-path-length` will be enforced, and the only intermediates that will be considered will be certs in the CMS CERTS-ONLY file defined via `service.intermediates.uri`
+      aia-chase: false
       max-path-length: 7
-      aia-chase: true
       revocation-enabled: true
       revocation-ee-only: true
       ocsp-enabled: true
@@ -50,4 +55,4 @@ logging:
     rollingpolicy:
       file-name-pattern: 'vss-%d{yyyy-MM-dd}.%i.log'
       max-file-size: 10MB
-      max-history: '7'
+      max-history: 7


### PR DESCRIPTION
- Adds support for separate System.out and System.err log
- Adds feature to log valid intermediates that are not cached as a warning for intermediate discovery if the AIA chase is enabled
- Adds example certpath debugging in startup script which includes thread and timestamp information
