### PR TITLE
Remove OpenAPI v3 Compliance badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 [![Build Status](https://github.com/grandamp/rest-service/actions/workflows/build.yml/badge.svg)](https://github.com/grandamp/rest-service/actions)
 
-[![OpenAPI v3 Compliance](https://validator.swagger.io/validator?url=https://home.keysupport.net/v3/api-docs)](https://home.keysupport.net/v3/api-docs)
-
 A WIP to replace the [Treasury SCVP service](https://github.com/GSA/ficam-scvp-testing/blob/master/utilities/vss2/README.md), with something more modern.
 
 Why?  Many mTLS use-cases involve complex certificate validation in the application layer, which is *hard* to scale.


### PR DESCRIPTION
Removed OpenAPI compliance badge from README.

The badge always appears invalid, likely due to TLS 1.3 issues with the OpenAPI service fetching of the API from the reference implementation.