### PR TITLE
Add FPKI Analysis Utility and Refactor Python Client

### DIFF
--- a/client/python/README.md
+++ b/client/python/README.md
@@ -2,6 +2,30 @@
 
 This is a quick and dirty Python client example.
 
+## FPKI Analysis Utility (`validate_fpki.py`)
+
+A command-line utility for validating all certificates found in the upstream federal `.p7b` file using the `rest-service` infrastructure.
+
+### Usage
+
+```bash
+# Ensure your virtual environment is active and dependencies are installed
+pip install -r requirements.txt
+
+# Run the script
+./validate_fpki.py
+```
+
+### Features
+
+- Automatically downloads the upstream `CACertificatesValidatingToFederalCommonPolicyG2.p7b`
+- Parses the PKCS7 data to extract all available certificates
+- Calls the Certificate Validation Service at `https://home.keysupport.org` for each certificate
+- Uses the `1.3.6.1.5.5.7.19.1` (Default) validation policy
+- Generates a neat command-line report separating Valid and Invalid certificates, with the failure reasons provided by the validation service.
+
+## Additional Notes
+
 *Break and Inspect Warning:* In the event the exampe below fails with an error similar to:
 
 ```TEXT

--- a/client/python/intermediates.py
+++ b/client/python/intermediates.py
@@ -18,7 +18,7 @@ def intermediates(host: str, policy: str) -> typing.Dict:
     response = requests.get(apiEndpointUri)
     return response.json()
 
-def printPEM(base64str: str) -> str:
+def printPEM(base64str: str) -> None:
     line = []
     # Add PEM header
     line.append("-----BEGIN CERTIFICATE-----")

--- a/client/python/validate.py
+++ b/client/python/validate.py
@@ -30,7 +30,7 @@ def loadCerts(file: str, type: FileEncoding) -> typing.List[x509.Certificate]:
     if type == FileEncoding.PEM:
         return x509.load_pem_x509_certificates(bytes)
     if type == FileEncoding.DER:
-        return x509.load_der_x509_certificate(bytes)
+        return [x509.load_der_x509_certificate(bytes)]
 
 def validate(host: str, policy: str, vssCert:str) -> typing.Dict:
     request = {"validationPolicyId":policy,"x509Certificate":vssCert}
@@ -41,7 +41,7 @@ def validate(host: str, policy: str, vssCert:str) -> typing.Dict:
     print("\nResponse:\n" + json.dumps(resJson, sort_keys=False, indent=4))
     return resJson
 
-def validateCert(certificate):
+def validateCert(certificate: x509.Certificate) -> None:
     vsscert = cert_to_base64(certificate)
     resJson = validate(host, policy, vsscert)
     x509IssuerName = resJson["x509IssuerName"]
@@ -51,10 +51,12 @@ def validateCert(certificate):
     sha256Thumbprint = resJson["x5t#S256"]
     sha256ThumbprintHex = base64.b64decode(sha256Thumbprint).hex()
     print("Thumbprint (SHA-256): " + sha256ThumbprintHex)
-    # TODO: Don't assume the certificate has a subjectKeyIdentifier value.  Use a Try statement.
-#    ski = certificate.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER)
-#    kid = ski.value.key_identifier.hex()
-#   print("kid: " + kid)
+    try:
+        ski = certificate.extensions.get_extension_for_oid(ExtensionOID.SUBJECT_KEY_IDENTIFIER)
+        kid = ski.value.key_identifier.hex()
+        print("kid: " + kid)
+    except x509.ExtensionNotFound:
+        pass
     certResult = resJson["validationResult"]["result"]
     print("Validation Result: " + certResult)
     if certResult == "FAIL":

--- a/client/python/validate_fpki.py
+++ b/client/python/validate_fpki.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import base64
+import requests
+import json
+import urllib3
+import typing
+import cryptography
+import datetime
+from cryptography.hazmat.primitives.serialization import pkcs7, Encoding
+from cryptography import x509
+
+urllib3.disable_warnings()
+
+P7B_URL = "https://www.idmanagement.gov/implement/tools/CACertificatesValidatingToFederalCommonPolicyG2.p7b"
+VSS_HOST = "https://home.keysupport.org"
+VSS_POLICY = "1.3.6.1.5.5.7.19.1"
+VSS_ENDPOINT = f"{VSS_HOST}/vss/v2/validate"
+
+def cert_to_base64(cert: x509.Certificate) -> str:
+    return base64.b64encode(cert.public_bytes(Encoding.DER)).decode("utf-8")
+
+def validate_cert(cert: x509.Certificate) -> typing.Dict:
+    vss_cert = cert_to_base64(cert)
+    request_data = {
+        "validationPolicyId": VSS_POLICY,
+        "x509Certificate": vss_cert
+    }
+    
+    try:
+        response = requests.post(VSS_ENDPOINT, json=request_data, verify=False, timeout=10)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        return {"error": str(e)}
+
+def main() -> None:
+    print(f"Fetching P7B from {P7B_URL} ...")
+    try:
+        res = requests.get(P7B_URL, timeout=30)
+        res.raise_for_status()
+        p7b_bytes = res.content
+    except Exception as e:
+        print(f"Failed to fetch P7B: {e}")
+        return
+
+    print("Parsing certificates...")
+    try:
+        certs = pkcs7.load_der_pkcs7_certificates(p7b_bytes)
+    except Exception as e:
+        print(f"Failed to parse P7B as DER: {e}")
+        # Try PEM just in case
+        try:
+            certs = pkcs7.load_pem_pkcs7_certificates(p7b_bytes)
+        except Exception as e2:
+            print(f"Failed to parse P7B as PEM too: {e2}")
+            return
+            
+    print(f"Found {len(certs)} certificates. Validating against {VSS_ENDPOINT} (policy: {VSS_POLICY})...")
+    
+    valid_certs = []
+    invalid_certs = []
+    error_certs = []
+    
+    for i, cert in enumerate(certs):
+        print(f"Validating cert {i+1}/{len(certs)}...", end="\r")
+        result = validate_cert(cert)
+        
+        subject = "Unknown"
+        try:
+            subject_attr = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+            if subject_attr:
+                subject = subject_attr[0].value
+            else:
+                subject = cert.subject.rfc4514_string()
+        except:
+            pass
+
+        if "error" in result:
+            error_certs.append((subject, result["error"]))
+            continue
+            
+        validation_res = result.get("validationResult", {})
+        status = validation_res.get("result", "UNKNOWN")
+        
+        if status == "SUCCESS":
+            valid_certs.append(subject)
+        else:
+            reason = validation_res.get("invalidityReasonText", "Unknown reason")
+            invalid_certs.append((subject, reason))
+            
+    print(" " * 50, end="\r") # clear progress line
+    
+    print("=" * 60)
+    print(f"FPKI ANALYSIS REPORT - {datetime.datetime.now(datetime.timezone.utc).isoformat()}")
+    print("=" * 60)
+    
+    print(f"\n--- VALID CERTIFICATES ({len(valid_certs)}) ---")
+    for subj in valid_certs:
+        print(f" - {subj}")
+        
+    print(f"\n--- INVALID CERTIFICATES ({len(invalid_certs)}) ---")
+    for subj, reason in invalid_certs:
+        print(f" - {subj}")
+        print(f"   Reason: {reason}")
+        
+    if error_certs:
+        print(f"\n--- VALIDATION ERRORS ({len(error_certs)}) ---")
+        for subj, err in error_certs:
+            print(f" - {subj}")
+            print(f"   Error: {err}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
This PR introduces a new Python utility to automatically analyze and validate upstream FPKI intermediates from `idmanagement.gov` against the Certificate Validation Service. It also includes several quality-of-life improvements, bug fixes, and a Dependabot-friendly dependencies file for the Python client examples.

### Key Changes
**New Features & Documentation:**
* **Added `validate_fpki.py`:** A new command-line utility that fetches the upstream `CACertificatesValidatingToFederalCommonPolicyG2.p7b` file, extracts the PKCS7 certificates, and validates them against the VSS default policy (`1.3.6.1.5.5.7.19.1`). It generates a neat CLI report separating Valid and Invalid certificates (including failure reasons).
* **Added `requirements.txt`:** Pinned dependencies (`cryptography`, `requests`, `typing`) to enable Dependabot tracking and simplify local setup.
* **Updated `README.md`:** Added usage instructions and feature details for the new FPKI analysis script.

**Code Refactoring & Fixes:**
* **Resolved `TODO` in `validate.py`:** Safely extracts the Subject Key Identifier (SKI) using a `try...except x509.ExtensionNotFound` block rather than assuming the extension is always present.
* **Fixed `loadCerts` return type:** Addressed a bug where loading a single DER file returned an object instead of a list, ensuring the `for` loop in `__main__` won't crash.
* **Type Hinting:** Fixed and completed missing Python type hints across `validate.py` and `intermediates.py` (e.g., correcting `printPEM` to return `None`).

### How to Test
1. Navigate to `client/python/`
2. Run `pip install -r requirements.txt`
3. Execute `./validate_fpki.py`
4. Verify the CLI outputs a clean report of Valid and Invalid certificates.